### PR TITLE
Test MRI 2.1 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   - jruby-18mode
   - jruby-19mode
   - rbx


### PR DESCRIPTION
I might be having segfaults on ruby 2.1, throwing this up in a pull to see if a simple travis run gets them
