### PR TITLE
"warning: instance variable @delegate not initialized"

### DIFF
--- a/lib/websocket/driver/server.rb
+++ b/lib/websocket/driver/server.rb
@@ -7,6 +7,7 @@ module WebSocket
       def initialize(socket, options = {})
         super
         @http = HTTP::Request.new
+        @delegate = nil
       end
 
       def env


### PR DESCRIPTION
This eliminates a Ruby :warning: when run with `RUBYOPT="-w"`