### PR TITLE
Work with ruby 2.3's --enable-frozen-string-literal

### DIFF
--- a/lib/websocket/driver/hybi/message.rb
+++ b/lib/websocket/driver/hybi/message.rb
@@ -14,7 +14,7 @@ module WebSocket
           @rsv2   = false
           @rsv3   = false
           @opcode = nil
-          @data   = Driver.encode('', :binary)
+          @data   = Driver.encode(String.new, :binary)
         end
 
         def <<(frame)

--- a/lib/websocket/driver/stream_reader.rb
+++ b/lib/websocket/driver/stream_reader.rb
@@ -6,7 +6,7 @@ module WebSocket
       MINIMUM_AUTOMATIC_PRUNE_OFFSET = 128
 
       def initialize
-        @buffer = Driver.encode('', :binary)
+        @buffer = Driver.encode(String.new, :binary)
         @offset = 0
       end
 


### PR DESCRIPTION
These changes are the minimal ones necessary to allow Roda's specs
to pass.  There may well be other changes that are required.