### PR TITLE
Removed dependency from EventMachine which is only used for examples

### DIFF
--- a/websocket-driver.gemspec
+++ b/websocket-driver.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'websocket-extensions', '>= 0.1.0'
 
-  s.add_development_dependency 'eventmachine'
   s.add_development_dependency 'permessage_deflate'
   s.add_development_dependency 'rake-compiler', '~> 0.8.0'
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
I think the hard dependency on eventmachine should be removed because this is only a protocol implementation detached from the actual I/O. In facts I am using it inside a custom actor model implementation (and I don't even want to see eventmachine installed! :) )

Thank you