### PR TITLE
Support ping in EventEmitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,14 @@ describing the error.
 Adds a callback block to execute when the socket becomes closed. The `event`
 object has `code` and `reason` attributes.
 
+#### `driver.on :ping, -> (event) { }`
+
+Adds a callback block to execute when a ping is received
+
+#### `driver.on :pong, -> (event) { }`
+
+Adds a callback block to execute when a pong is received
+
 #### `driver.add_extension(extension)`
 
 Registers a protocol extension whose operation will be negotiated via the

--- a/lib/websocket/driver/hybi.rb
+++ b/lib/websocket/driver/hybi.rb
@@ -367,9 +367,11 @@ module WebSocket
             shutdown(code || DEFAULT_ERROR_CODE, reason || '')
 
           when OPCODES[:ping] then
+            emit :ping, MessageEvent.new(payload)
             frame(payload, :pong)
 
           when OPCODES[:pong] then
+            emit :pong, MessageEvent.new(payload)
             message = Driver.encode(payload, UNICODE)
             callback = @ping_callbacks[message]
             @ping_callbacks.delete(message)

--- a/spec/websocket/driver/hybi_spec.rb
+++ b/spec/websocket/driver/hybi_spec.rb
@@ -359,6 +359,14 @@ describe WebSocket::Driver::Hybi do
         expect(@bytes).to eq [0x8a, 0x04, 0x4f, 0x48, 0x41, 0x49]
       end
 
+      it "emits a :ping event when a server-sent ping arrives" do
+        driver.on(:ping) { @ping_event_fired = true }
+        driver.on(:pong) { @pong_event_fired = true }
+        driver.parse [0x89, 0x04, 0x4f, 0x48, 0x41, 0x49].pack("C*")
+        expect(@ping_event_fired).to eq true
+        expect(@pong_event_fired).to_not eq true
+      end
+
       describe "when a message listener raises an error" do
         before do
           @messages = []
@@ -434,6 +442,14 @@ describe WebSocket::Driver::Hybi do
         driver.ping("Hi") { @reply = true }
         driver.parse [0x8a, 0x02, 72, 105].pack("C*")
         expect(@reply).to eq true
+      end
+
+      it "emits a :pong event when pong reply for ping received" do
+        driver.on(:ping) { @ping_event_fired = true }
+        driver.on(:pong) { @pong_event_fired = true }
+        driver.parse [0x8a, 0x02, 72, 105].pack("C*")
+        expect(@pong_event_fired).to eq true
+        expect(@ping_event_fired).to_not eq true
       end
 
       it "does not run the callback on non-matching pong" do


### PR DESCRIPTION
Our client library that relies on this WebSocket library for it's socket transport attempts to use native WS ping/pong frames to keep track of liveness of a connection.

Unfortunately the WebSocket driver does not support `:ping` and `:pong` events, so I've added them.

Hopefully you'll be happy with these proposed changes and I can add support for native WebSockets to our library again. See https://github.com/ably/ably-ruby/commit/ee038c398fb91bd2fed55f1cafcc498bad178179