### PR TITLE
Fix No Method Error by request without Sec-Websocket-Key header

### DIFF
--- a/spec/websocket/driver/hybi_spec.rb
+++ b/spec/websocket/driver/hybi_spec.rb
@@ -133,12 +133,12 @@ describe WebSocket::Driver::Hybi do
 
         it "triggers the onerror event" do
           driver.start
-          expect(@error.message).to eq "Invalid Sec-WebSocket-Extensions header: x-webkit- -frame"
+          expect(@error.message).to eq "No Sec-WebSocket-Key header"
         end
 
         it "triggers the onclose event" do
           driver.start
-          expect(@close).to eq [1002, "Invalid Sec-WebSocket-Extensions header: x-webkit- -frame"]
+          expect(@close).to eq [1002, "No Sec-WebSocket-Key header"]
         end
 
         it "changes the state to :closed" do
@@ -157,8 +157,8 @@ describe WebSocket::Driver::Hybi do
               "HTTP/1.1 101 Switching Protocols\r\n" +
               "Upgrade: websocket\r\n" +
               "Connection: Upgrade\r\n" +
-              "Sec-WebSocket-Accept: JdiiuafpBKRqD7eol0y4vJDTsTs=\r\n" +
               "Authorization: Bearer WAT\r\n" +
+              "Sec-WebSocket-Accept: JdiiuafpBKRqD7eol0y4vJDTsTs=\r\n" +
               "\r\n")
           driver.start
         end

--- a/spec/websocket/driver/hybi_spec.rb
+++ b/spec/websocket/driver/hybi_spec.rb
@@ -116,6 +116,37 @@ describe WebSocket::Driver::Hybi do
         end
       end
 
+      describe "without Sec-WebSocket-Key" do
+        before do
+          env["HTTP_SEC_WEBSOCKET_KEY"] = nil
+        end
+
+        it "does not write a handshake" do
+          expect(socket).not_to receive(:write)
+          driver.start
+        end
+
+        it "does not trigger the onopen event" do
+          driver.start
+          expect(@open).to eq false
+        end
+
+        it "triggers the onerror event" do
+          driver.start
+          expect(@error.message).to eq "Invalid Sec-WebSocket-Extensions header: x-webkit- -frame"
+        end
+
+        it "triggers the onclose event" do
+          driver.start
+          expect(@close).to eq [1002, "Invalid Sec-WebSocket-Extensions header: x-webkit- -frame"]
+        end
+
+        it "changes the state to :closed" do
+          driver.start
+          expect(driver.state).to eq :closed
+        end
+      end
+
       describe "with custom headers" do
         before do
           driver.set_header "Authorization", "Bearer WAT"


### PR DESCRIPTION
This case is invalid WebSocket request.

This error occurred on [my commit](https://github.com/mataki/websocket-driver-ruby/commit/f1aa182bd218505c0d3e20dbda154b575e97e96e).

```
Failures:

  1) WebSocket::Driver::Hybi in the :connecting state start without Sec-WebSocket-Key does not write a handshake
     Failure/Error: Base64.strict_encode64(Digest::SHA1.digest(key + GUID))
     
     NoMethodError:
       undefined method `+' for nil:NilClass
     # ./lib/websocket/driver/hybi.rb:11:in `generate_accept'
     # ./lib/websocket/driver/hybi.rb:76:in `initialize'
     # ./spec/websocket/driver/hybi_spec.rb:32:in `new'
     # ./spec/websocket/driver/hybi_spec.rb:32:in `block (2 levels) in <top (required)>'
     # ./spec/websocket/driver/hybi_spec.rb:126:in `block (5 levels) in <top (required)>'
```

