### PR TITLE
Prefer to use actual options where possible.

### DIFF
--- a/lib/websocket/driver.rb
+++ b/lib/websocket/driver.rb
@@ -71,14 +71,14 @@ module WebSocket
     include EventEmitter
     attr_reader :protocol, :ready_state
 
-    def initialize(socket, options = {})
+    def initialize(socket, max_length: MAX_LENGTH, **options)
       super()
-      Driver.validate_options(options, [:max_length, :masking, :require_masking, :protocols])
+      Driver.validate_options(options, [:masking, :require_masking, :protocols])
 
       @socket      = socket
       @reader      = StreamReader.new
       @options     = options
-      @max_length  = options[:max_length] || MAX_LENGTH
+      @max_length  = max_length
       @headers     = Headers.new
       @queue       = []
       @ready_state = 0

--- a/lib/websocket/driver/client.rb
+++ b/lib/websocket/driver/client.rb
@@ -10,7 +10,7 @@ module WebSocket
 
       attr_reader :status, :headers
 
-      def initialize(socket, options = {})
+      def initialize(socket, **options)
         super
 
         @ready_state = -1

--- a/lib/websocket/driver/server.rb
+++ b/lib/websocket/driver/server.rb
@@ -4,7 +4,7 @@ module WebSocket
     class Server < Driver
       EVENTS = %w[open message error close]
 
-      def initialize(socket, options = {})
+      def initialize(socket, **options)
         super
         @http = HTTP::Request.new
         @delegate = nil


### PR DESCRIPTION
We could look at turning `:masking, :require_masking, :protocols` into instance variables too, so they can become proper options.