### PR TITLE
Rack input frozen string

### DIFF
--- a/lib/websocket/driver/draft76.rb
+++ b/lib/websocket/driver/draft76.rb
@@ -8,7 +8,9 @@ module WebSocket
         super
         input  = @socket.env['rack.input']
         @stage = -1
-        @body  = (input ? input.read : String.new('')).force_encoding(BINARY)
+        input_string = (input ? input.read : String.new(''))
+        input_string = input_string.dup if input_string.frozen?
+        @body  = input_string.force_encoding(BINARY)
 
         @headers.clear
         @headers['Upgrade'] = 'WebSocket'

--- a/lib/websocket/driver/draft76.rb
+++ b/lib/websocket/driver/draft76.rb
@@ -6,11 +6,10 @@ module WebSocket
 
       def initialize(socket, options = {})
         super
-        input  = @socket.env['rack.input']
+        input  = (@socket.env['rack.input'] || StringIO.new('')).read
+        input = input.dup if input.frozen?
         @stage = -1
-        input_string = (input ? input.read : String.new(''))
-        input_string = input_string.dup if input_string.frozen?
-        @body  = input_string.force_encoding(BINARY)
+        @body  = input.force_encoding(BINARY)
 
         @headers.clear
         @headers['Upgrade'] = 'WebSocket'

--- a/spec/websocket/driver/draft76_spec.rb
+++ b/spec/websocket/driver/draft76_spec.rb
@@ -226,4 +226,21 @@ describe WebSocket::Driver::Draft76 do
       end
     end
   end
+
+  describe "frozen rack.input.read" do
+    let :frozen_env do
+      # Make up a rack.input that somehow returns a frozen string on input.read
+      # We're seeing this error occasionally when using ActionCable in Rails 5.2
+      env.merge("rack.input" => Struct.new(:read).new(''.freeze))
+    end
+
+    it 'edge case where rack.input.read returns a frozen string' do
+      frozen_socket = socket
+      allow(frozen_socket).to receive(:env).and_return(frozen_env)
+
+      expect {
+        WebSocket::Driver::Draft76.new(frozen_socket)
+      }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
We're seeing this occasionally in our error logs, where the `env` passed into to the driver will return a frozen string when read. And we'll get the following error:

      FrozenError: can't modify frozen String

The stack trace always includes ActionCable in to the mix, so it looks something like this:

      "/app/vendor/bundle/ruby/2.6.0/gems/websocket-driver-0.7.0/lib/websocket/driver/draft76.rb" line 11 in force_encoding
      "/app/vendor/bundle/ruby/2.6.0/gems/websocket-driver-0.7.0/lib/websocket/driver/draft76.rb" line 11 in initialize
      "/app/vendor/bundle/ruby/2.6.0/gems/websocket-driver-0.7.0/lib/websocket/driver.rb" line 162 in new
      "/app/vendor/bundle/ruby/2.6.0/gems/websocket-driver-0.7.0/lib/websocket/driver.rb" line 162 in rack
      "/app/vendor/bundle/ruby/2.6.0/gems/actioncable-5.2.3/lib/action_cable/connection/client_socket.rb" line 47 in initialize
      "/app/vendor/bundle/ruby/2.6.0/gems/actioncable-5.2.3/lib/action_cable/connection/web_socket.rb" line 10 in new
      "/app/vendor/bundle/ruby/2.6.0/gems/actioncable-5.2.3/lib/action_cable/connection/web_socket.rb" line 10 in initialize
      "/app/vendor/bundle/ruby/2.6.0/gems/actioncable-5.2.3/lib/action_cable/connection/base.rb" line 59 in new
      "/app/vendor/bundle/ruby/2.6.0/gems/actioncable-5.2.3/lib/action_cable/connection/base.rb" line 59 in initialize
      "/app/vendor/bundle/ruby/2.6.0/gems/actioncable-5.2.3/lib/action_cable/server/base.rb" line 30 in new
      "/app/vendor/bundle/ruby/2.6.0/gems/actioncable-5.2.3/lib/action_cable/server/base.rb" line 30 in call

I still don't quite know why someone is sometimes returning a frozen string (it could also have to with any of the current rack middleware we're using), but I do know that we can handle it here.

So this adds a spec and some behavior to fix that. Let me know if it doesn't belong here or needs some touchups.

(And thanks for writing websocket-driver)