### PR TITLE
Update websocket-extensions to address CVE-2020-7663

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.7.2.1 / 2020-06-05
+
+- Bump websocket-extensions dependency to 0.15 to address CVE-2020-7663
+
 ### 0.7.2 / 2020-05-22
 
 - Emit `ping` and `pong` events from the `Server` driver

--- a/websocket-driver.gemspec
+++ b/websocket-driver.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name     = 'websocket-driver'
-  s.version  = '0.7.2'
+  s.version  = '0.7.2.1'
   s.summary  = 'WebSocket protocol handler with pluggable I/O'
   s.author   = 'James Coglan'
   s.email    = 'jcoglan@gmail.com'

--- a/websocket-driver.gemspec
+++ b/websocket-driver.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.files = files
 
-  s.add_dependency 'websocket-extensions', '>= 0.1.0'
+  s.add_dependency 'websocket-extensions', '>= 0.1.5'
 
   s.add_development_dependency 'eventmachine'
   s.add_development_dependency 'permessage_deflate'


### PR DESCRIPTION
See the CVE [here](https://nvd.nist.gov/vuln/detail/CVE-2020-7663). The fix is just to bump the version.