### PR TITLE
Flag files that modify string literals

### DIFF
--- a/lib/websocket/driver/hybi.rb
+++ b/lib/websocket/driver/hybi.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 module WebSocket
   class Driver
 

--- a/spec/websocket/driver/draft76_spec.rb
+++ b/spec/websocket/driver/draft76_spec.rb
@@ -1,4 +1,5 @@
 # encoding=utf-8
+# frozen_string_literal: false
 
 require "spec_helper"
 


### PR DESCRIPTION
When running in an environment that freezes string literals by default, `hybi.rb` raises exceptions as it modifies the `format = 'C2'` string (line 224). 

Adding the magic comment supports this use case without modifying behavior for anyone else. I added it to one spec too, so that running specs this way (`RUBYOPT="--enable=frozen-string-literal" rspec`) keeps them all passing.