### PR TITLE
add base64 gem to gemspec

### DIFF
--- a/websocket-driver.gemspec
+++ b/websocket-driver.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
 
   s.files = files
 
+  s.add_dependency 'base64'
   s.add_dependency 'websocket-extensions', '>= 0.1.0'
 
   s.add_development_dependency 'eventmachine'


### PR DESCRIPTION
base64 will no longer be a default gem from ruby 3.4 onwards.