### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/websocker-driver

### DIFF
--- a/websocket-driver.gemspec
+++ b/websocket-driver.gemspec
@@ -35,4 +35,6 @@ Gem::Specification.new do |s|
   if RUBY_VERSION < '2.0.0'
     s.add_development_dependency 'rake', '< 12.3.0'
   end
+
+  s.metadata['changelog_uri'] = s.homepage + '/blob/main/CHANGELOG.md'
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/websocker-driver which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/#metadata